### PR TITLE
Improve rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
   "extends": "./index.js",
+  "env": {
+    "node": true
+  }
 }

--- a/rules/es2015/style.js
+++ b/rules/es2015/style.js
@@ -26,6 +26,10 @@ module.exports = {
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-webpack-loader-syntax.md
     'import/no-webpack-loader-syntax': 'error',
 
+    // Enforce a convention in module import order
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md
+    'import/order': 'error',
+
     // Require modules with a single export to use a default export
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/prefer-default-export.md
     'import/prefer-default-export': 'error',
@@ -41,6 +45,10 @@ module.exports = {
     // Require variables to be declared with let or const instead of var
     // http://eslint.org/docs/rules/no-var
     'no-var': 'error',
+
+    // Suggest using const
+    // https://eslint.org/docs/rules/prefer-const
+    'prefer-const': 'error',
 
     // Require template literals instead of string concat
     // http://eslint.org/docs/rules/prefer-template

--- a/rules/general/error.js
+++ b/rules/general/error.js
@@ -4,7 +4,15 @@ module.exports = {
 
     // Ensure RegExp strings are valid
     // http://eslint.org/docs/rules/no-invalid-regexp
-    'no-invalid-regexp': 'error'
+    'no-invalid-regexp': 'error',
+
+    // Disallow undeclared variables
+    // https://eslint.org/docs/rules/no-undef
+    'no-undef': 'error',
+
+    // Disallow unused variables
+    // https://eslint.org/docs/rules/no-unused-vars
+    'no-unused-vars': 'error',
 
   }
 

--- a/rules/general/format.js
+++ b/rules/general/format.js
@@ -128,6 +128,14 @@ module.exports = {
     // http://eslint.org/docs/rules/space-before-blocks
     'space-before-blocks': ['error', 'always'],
 
+    // Require a space before function parenthesis in non-named functions
+    // https://eslint.org/docs/rules/space-before-function-paren
+    'space-before-function-paren': ['error', {
+      anonymous: 'always',
+      named: 'never',
+      asyncArrow: 'always'
+    }],
+
     // Prohibit spaces inside parens (immediately adjacent to paren)
     // http://eslint.org/docs/rules/space-in-parens
     'space-in-parens': ['error', 'never'],


### PR DESCRIPTION
Closes #1, by adding `import/order`, `no-undef`, `no-unused-vars` and `prefer-const`.

Turns out eslint-plugin-import's `import/order` and eslint's `sort-imports` do not play nicely together, so for now imports are required to be grouped properly, not necessarily sorted correctly alphabetically. An issue is currently tracking [enhancing `import/order` to include sorting](https://github.com/benmosher/eslint-plugin-import/issues/389).

To ensure this repo lints correctly, this PR also enables the Node environment in `.eslintrc.`