### PR TITLE
Reference ESLint over HTTPS

### DIFF
--- a/rules/es2015/error.js
+++ b/rules/es2015/error.js
@@ -3,7 +3,7 @@ module.exports = {
   rules: {
 
     // Ensure presence of super() in constructors (for derived classes)
-    // http://eslint.org/docs/rules/constructor-super
+    // https://eslint.org/docs/rules/constructor-super
     'constructor-super': 'error',
 
     // Ensure imports point to resolveable modules
@@ -14,11 +14,11 @@ module.exports = {
     }],
 
     // Ensure const variables are not reassigned or modified
-    // http://eslint.org/docs/rules/no-const-assign
+    // https://eslint.org/docs/rules/no-const-assign
     'no-const-assign': 'error',
 
     // Ensure super() is called first in constructors (for derived classes)
-    // http://eslint.org/docs/rules/no-this-before-super
+    // https://eslint.org/docs/rules/no-this-before-super
     'no-this-before-super': 'error',
 
   }

--- a/rules/es2015/style.js
+++ b/rules/es2015/style.js
@@ -35,15 +35,15 @@ module.exports = {
     'import/prefer-default-export': 'error',
 
     // Prohibit silently overriding class members
-    // http://eslint.org/docs/rules/no-dupe-class-members
+    // https://eslint.org/docs/rules/no-dupe-class-members
     'no-dupe-class-members': 'error',
 
     // Prohibit constructors when default is sufficient
-    // http://eslint.org/docs/rules/no-useless-constructor
+    // https://eslint.org/docs/rules/no-useless-constructor
     'no-useless-constructor': 'error',
 
     // Require variables to be declared with let or const instead of var
-    // http://eslint.org/docs/rules/no-var
+    // https://eslint.org/docs/rules/no-var
     'no-var': 'error',
 
     // Suggest using const
@@ -51,7 +51,7 @@ module.exports = {
     'prefer-const': 'error',
 
     // Require template literals instead of string concat
-    // http://eslint.org/docs/rules/prefer-template
+    // https://eslint.org/docs/rules/prefer-template
     'prefer-template': 'error',
 
   }

--- a/rules/general/error.js
+++ b/rules/general/error.js
@@ -3,7 +3,7 @@ module.exports = {
   rules: {
 
     // Ensure RegExp strings are valid
-    // http://eslint.org/docs/rules/no-invalid-regexp
+    // https://eslint.org/docs/rules/no-invalid-regexp
     'no-invalid-regexp': 'error',
 
     // Disallow undeclared variables

--- a/rules/general/format.js
+++ b/rules/general/format.js
@@ -3,35 +3,35 @@ module.exports = {
   rules: {
 
     // Prohibit space before or after array brackets, apart from line breaks
-    // http://eslint.org/docs/rules/array-bracket-spacing
+    // https://eslint.org/docs/rules/array-bracket-spacing
     'array-bracket-spacing': ['error', 'never'],
 
     // Require one true brace style, but allow single line braces
-    // http://eslint.org/docs/rules/brace-style
+    // https://eslint.org/docs/rules/brace-style
     'brace-style': ['error', '1tbs', {
       allowSingleLine: true
     }],
 
     // Require camelcased names, except for properties
-    // http://eslint.org/docs/rules/camelcase
+    // https://eslint.org/docs/rules/camelcase
     'camelcase': ['error', {
       properties: 'never'
     }],
 
     // Require braces for control statements, except when control statement shares the line
-    // http://eslint.org/docs/rules/curly
+    // https://eslint.org/docs/rules/curly
     'curly': ['error', 'multi-line'],
 
     // Require newlines at file end
-    // http://eslint.org/docs/rules/eol-last
+    // https://eslint.org/docs/rules/eol-last
     'eol-last': ['error', 'always'],
 
     // Prohibit space between function name and opening call paren
-    // http://eslint.org/docs/rules/func-call-spacing
+    // https://eslint.org/docs/rules/func-call-spacing
     'func-call-spacing': ['error', 'never'],
 
     // Enforce 2-space indentation level, with 1 indentation level for several cases
-    // http://eslint.org/docs/rules/indent
+    // https://eslint.org/docs/rules/indent
     'indent': ['error', 2, {
       SwitchCase: 1,
       VariableDeclarator: 1,
@@ -47,7 +47,7 @@ module.exports = {
     }],
 
     // Require spacing before and after common keywords, except in certain cases
-    // http://eslint.org/docs/rules/keyword-spacing
+    // https://eslint.org/docs/rules/keyword-spacing
     'keyword-spacing': ['error', {
       before: true,
       after: true,
@@ -59,18 +59,18 @@ module.exports = {
     }],
 
     // Require only-LF line breaks
-    // http://eslint.org/docs/rules/linebreak-style
+    // https://eslint.org/docs/rules/linebreak-style
     'linebreak-style': ['error', 'unix'],
 
     // Require newlines above and below directives
-    // http://eslint.org/docs/rules/lines-around-directive
+    // https://eslint.org/docs/rules/lines-around-directive
     'lines-around-directive': ['error', {
       before: 'always',
       after: 'always',
     }],
 
     // Limit line length to 100 and tab width to 2, except in certain cases
-    // http://eslint.org/docs/rules/max-len
+    // https://eslint.org/docs/rules/max-len
     'max-len': ['error', 100, 2, {
       ignoreUrls: true,
       ignoreComments: false,
@@ -80,52 +80,52 @@ module.exports = {
     }],
 
     // Require parens when calling a constructor
-    // http://eslint.org/docs/rules/new-parens
+    // https://eslint.org/docs/rules/new-parens
     'new-parens': 'error',
 
     // Prohibit empty statements
-    // http://eslint.org/docs/rules/no-empty
+    // https://eslint.org/docs/rules/no-empty
     'no-empty': 'error',
 
     // Prohibit superfluous semicolons
-    // http://eslint.org/docs/rules/no-extra-semi
+    // https://eslint.org/docs/rules/no-extra-semi
     'no-extra-semi': 'error',
 
     // Prohibit mixing of tabs and spaces
-    // http://eslint.org/docs/rules/no-mixed-spaces-and-tabs
+    // https://eslint.org/docs/rules/no-mixed-spaces-and-tabs
     'no-mixed-spaces-and-tabs': 'error',
 
     // Prohibit more than one consecutive empty line, and enforce only one newline at EOF
-    // http://eslint.org/docs/rules/no-multiple-empty-lines
+    // https://eslint.org/docs/rules/no-multiple-empty-lines
     'no-multiple-empty-lines': ['error', {
       max: 2,
       maxEOF: 1
     }],
 
     // Prohibit more than one consecutive space in RegExp literals
-    // http://eslint.org/docs/rules/no-regex-spaces
+    // https://eslint.org/docs/rules/no-regex-spaces
     'no-regex-spaces': 'error',
 
     // Prohibit tab characters
-    // http://eslint.org/docs/rules/no-tabs
+    // https://eslint.org/docs/rules/no-tabs
     'no-tabs': 'error',
 
     // Require padding inside curly braces
-    // http://eslint.org/docs/rules/object-curly-spacing
+    // https://eslint.org/docs/rules/object-curly-spacing
     'object-curly-spacing': ['error', 'always'],
 
     // Require all object properties to be on the same line, or one-per-line (not mixed)
-    // http://eslint.org/docs/rules/object-property-newline
+    // https://eslint.org/docs/rules/object-property-newline
     'object-property-newline': ['error', {
       allowMultiplePropertiesPerLine: true,
     }],
 
     // Require semicolons at the end of statements
-    // http://eslint.org/docs/rules/semi
+    // https://eslint.org/docs/rules/semi
     'semi': ['error', 'always'],
 
     // Require a space or newline before opening of blocks
-    // http://eslint.org/docs/rules/space-before-blocks
+    // https://eslint.org/docs/rules/space-before-blocks
     'space-before-blocks': ['error', 'always'],
 
     // Require a space before function parenthesis in non-named functions
@@ -137,19 +137,19 @@ module.exports = {
     }],
 
     // Prohibit spaces inside parens (immediately adjacent to paren)
-    // http://eslint.org/docs/rules/space-in-parens
+    // https://eslint.org/docs/rules/space-in-parens
     'space-in-parens': ['error', 'never'],
 
     // Require spaces around operators
-    // http://eslint.org/docs/rules/space-infix-ops
+    // https://eslint.org/docs/rules/space-infix-ops
     'space-infix-ops': 'error',
 
     // Require spaces around placeholders in template strings
-    // http://eslint.org/docs/rules/template-curly-spacing
+    // https://eslint.org/docs/rules/template-curly-spacing
     'template-curly-spacing': 'error',
 
     // Prohibit the Unicode byte order marker
-    // http://eslint.org/docs/rules/unicode-bom
+    // https://eslint.org/docs/rules/unicode-bom
     'unicode-bom': ['error', 'never'],
 
   }

--- a/rules/general/style.js
+++ b/rules/general/style.js
@@ -3,41 +3,41 @@ module.exports = {
   rules: {
 
     // Require type-safe equality comparisons, except when comparing with null literals
-    // http://eslint.org/docs/rules/eqeqeq
+    // https://eslint.org/docs/rules/eqeqeq
     'eqeqeq': ['error', 'always', {
       'null': 'ignore'
     }],
 
     // Warn on use of console
-    // http://eslint.org/docs/rules/no-console
+    // https://eslint.org/docs/rules/no-console
     'no-console': 'warn',
 
     // Prohibit overwriting / reassigning exception objects
-    // http://eslint.org/docs/rules/no-ex-assign
+    // https://eslint.org/docs/rules/no-ex-assign
     'no-ex-assign': 'error',
 
     // Prohibit overwriting / reassigning function declarations
-    // http://eslint.org/docs/rules/no-func-assign
+    // https://eslint.org/docs/rules/no-func-assign
     'no-func-assign': 'error',
 
     // Prohibit variable redeclarations
-    // http://eslint.org/docs/rules/no-redeclare
+    // https://eslint.org/docs/rules/no-redeclare
     'no-redeclare': 'error',
 
     // Prohibit variable assignment in return statement
-    // http://eslint.org/docs/rules/no-return-assign
+    // https://eslint.org/docs/rules/no-return-assign
     'no-return-assign': 'error',
 
     // Prohibit unreachable code after return, throw, continue, or break
-    // http://eslint.org/docs/rules/no-unreachable
+    // https://eslint.org/docs/rules/no-unreachable
     'no-unreachable': 'error',
 
     // Prohibit left-side operand negation with relational operators
-    // http://eslint.org/docs/rules/no-unsafe-negation
+    // https://eslint.org/docs/rules/no-unsafe-negation
     'no-unsafe-negation': 'error',
 
     // Prohibit invalid JSDoc annotations (when present)
-    // http://eslint.org/docs/rules/valid-jsdoc
+    // https://eslint.org/docs/rules/valid-jsdoc
     'valid-jsdoc': 'error'
 
   }


### PR DESCRIPTION
Not a biggie, just normalizes all references to the ESLint docs to use HTTPS.