### PR TITLE
Prohibit padded blocks

### DIFF
--- a/rules/general/style.js
+++ b/rules/general/style.js
@@ -36,6 +36,10 @@ module.exports = {
     // http://eslint.org/docs/rules/no-unsafe-negation
     'no-unsafe-negation': 'error',
 
+    // Prohibit padding at beginning/end of blocks, classes and switch statements
+    // https://eslint.org/docs/rules/padded-blocks
+    'padded-blocks': ['error', 'never'],
+
     // Prohibit invalid JSDoc annotations (when present)
     // http://eslint.org/docs/rules/valid-jsdoc
     'valid-jsdoc': 'error'


### PR DESCRIPTION
This change prohibits padding at beginning/end of blocks, classes and switch statements.