### PR TITLE
Enforce comma dangle for multiline scenarios

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports = {
     './rules/general/style',
     './rules/general/error',
     './rules/es2015/style',
-    './rules/es2015/error'
+    './rules/es2015/error',
   ].map(require.resolve),
 
   parserOptions: {
@@ -16,10 +16,10 @@ module.exports = {
   },
 
   plugins: [
-    'import'
+    'import',
   ],
 
   rules: {
     strict: 'error',
-  }
+  },
 };

--- a/rules/es2015/error.js
+++ b/rules/es2015/error.js
@@ -8,7 +8,7 @@ module.exports = {
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md
     'import/no-unresolved': ['error', {
       commonjs: true,
-      caseSensitive: true
+      caseSensitive: true,
     }],
 
     // Ensure const variables are not reassigned or modified
@@ -18,5 +18,5 @@ module.exports = {
     // Ensure super() is called first in constructors (for derived classes)
     // https://eslint.org/docs/rules/no-this-before-super
     'no-this-before-super': 'error',
-  }
+  },
 };

--- a/rules/es2015/style.js
+++ b/rules/es2015/style.js
@@ -51,5 +51,5 @@ module.exports = {
     // Require template literals instead of string concat
     // https://eslint.org/docs/rules/prefer-template
     'prefer-template': 'error',
-  }
+  },
 };

--- a/rules/general/error.js
+++ b/rules/general/error.js
@@ -11,5 +11,5 @@ module.exports = {
     // Disallow unused variables
     // https://eslint.org/docs/rules/no-unused-vars
     'no-unused-vars': 'error',
-  }
+  },
 };

--- a/rules/general/format.js
+++ b/rules/general/format.js
@@ -7,13 +7,13 @@ module.exports = {
     // Require one true brace style, but allow single line braces
     // https://eslint.org/docs/rules/brace-style
     'brace-style': ['error', '1tbs', {
-      allowSingleLine: true
+      allowSingleLine: true,
     }],
 
     // Require camelcased names, except for properties
     // https://eslint.org/docs/rules/camelcase
     'camelcase': ['error', {
-      properties: 'never'
+      properties: 'never',
     }],
 
     // Require trailing commas when the last element is on a different line
@@ -41,12 +41,12 @@ module.exports = {
       outerIIFEBody: 1,
       FunctionDeclaration: {
         parameters: 1,
-        body: 1
+        body: 1,
       },
       FunctionExpression: {
         parameters: 1,
-        body: 1
-      }
+        body: 1,
+      },
     }],
 
     // Require spacing before and after common keywords, except in certain cases
@@ -57,8 +57,8 @@ module.exports = {
       overrides: {
         return: { after: true },
         throw: { after: true },
-        case: { after: true }
-      }
+        case: { after: true },
+      },
     }],
 
     // Require only-LF line breaks
@@ -102,7 +102,7 @@ module.exports = {
     // https://eslint.org/docs/rules/no-multiple-empty-lines
     'no-multiple-empty-lines': ['error', {
       max: 2,
-      maxEOF: 1
+      maxEOF: 1,
     }],
 
     // Prohibit more than one consecutive space in RegExp literals
@@ -136,7 +136,7 @@ module.exports = {
     'space-before-function-paren': ['error', {
       anonymous: 'always',
       named: 'never',
-      asyncArrow: 'always'
+      asyncArrow: 'always',
     }],
 
     // Prohibit spaces inside parens (immediately adjacent to paren)
@@ -154,5 +154,5 @@ module.exports = {
     // Prohibit the Unicode byte order marker
     // https://eslint.org/docs/rules/unicode-bom
     'unicode-bom': ['error', 'never'],
-  }
+  },
 };

--- a/rules/general/format.js
+++ b/rules/general/format.js
@@ -16,6 +16,11 @@ module.exports = {
       properties: 'never'
     }],
 
+    // Require trailing commas when the last element is on a different line
+    // than the closing bracket or curly brace
+    // https://eslint.org/docs/rules/comma-dangle
+    'comma-dangle': ['error', 'always-multiline'],
+
     // Require braces for control statements, except when control statement shares the line
     // https://eslint.org/docs/rules/curly
     'curly': ['error', 'multi-line'],

--- a/rules/general/style.js
+++ b/rules/general/style.js
@@ -3,7 +3,7 @@ module.exports = {
     // Require type-safe equality comparisons, except when comparing with null literals
     // https://eslint.org/docs/rules/eqeqeq
     'eqeqeq': ['error', 'always', {
-      'null': 'ignore'
+      'null': 'ignore',
     }],
 
     // Warn on use of console
@@ -40,6 +40,6 @@ module.exports = {
 
     // Prohibit invalid JSDoc annotations (when present)
     // https://eslint.org/docs/rules/valid-jsdoc
-    'valid-jsdoc': 'error'
-  }
+    'valid-jsdoc': 'error',
+  },
 };


### PR DESCRIPTION
This change enforces trailing commas but only in multiline scenarios, so:

```js
const list = [1, 2]; // this is fine

const multilineList = [
  1,
  2, // requires comma here (also in object literals)
];
```

Seem to recall we briefly discussed this multiple times @fallenoak but I can't recall what we landed on 😄 What do you think? If anything I think we should enforce or prohibit so that the code style is consistent.