### PR TITLE
Remove padding from object literals

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 module.exports = {
-
   extends: [
     './rules/general/format',
     './rules/general/style',
@@ -23,5 +22,4 @@ module.exports = {
   rules: {
     strict: 'error',
   }
-
 };

--- a/rules/es2015/error.js
+++ b/rules/es2015/error.js
@@ -1,7 +1,5 @@
 module.exports = {
-
   rules: {
-
     // Ensure presence of super() in constructors (for derived classes)
     // https://eslint.org/docs/rules/constructor-super
     'constructor-super': 'error',
@@ -20,7 +18,5 @@ module.exports = {
     // Ensure super() is called first in constructors (for derived classes)
     // https://eslint.org/docs/rules/no-this-before-super
     'no-this-before-super': 'error',
-
   }
-
 };

--- a/rules/es2015/style.js
+++ b/rules/es2015/style.js
@@ -1,7 +1,5 @@
 module.exports = {
-
   rules: {
-
     // Require import statements to appear before non-import statements (absolute-before-relative)
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/first.md
     'import/first': ['error', 'absolute-first'],
@@ -53,7 +51,5 @@ module.exports = {
     // Require template literals instead of string concat
     // https://eslint.org/docs/rules/prefer-template
     'prefer-template': 'error',
-
   }
-
 };

--- a/rules/general/error.js
+++ b/rules/general/error.js
@@ -1,7 +1,5 @@
 module.exports = {
-
   rules: {
-
     // Ensure RegExp strings are valid
     // https://eslint.org/docs/rules/no-invalid-regexp
     'no-invalid-regexp': 'error',
@@ -13,7 +11,5 @@ module.exports = {
     // Disallow unused variables
     // https://eslint.org/docs/rules/no-unused-vars
     'no-unused-vars': 'error',
-
   }
-
 };

--- a/rules/general/format.js
+++ b/rules/general/format.js
@@ -1,7 +1,5 @@
 module.exports = {
-
   rules: {
-
     // Prohibit space before or after array brackets, apart from line breaks
     // https://eslint.org/docs/rules/array-bracket-spacing
     'array-bracket-spacing': ['error', 'never'],
@@ -151,7 +149,5 @@ module.exports = {
     // Prohibit the Unicode byte order marker
     // https://eslint.org/docs/rules/unicode-bom
     'unicode-bom': ['error', 'never'],
-
   }
-
 };

--- a/rules/general/style.js
+++ b/rules/general/style.js
@@ -1,7 +1,5 @@
 module.exports = {
-
   rules: {
-
     // Require type-safe equality comparisons, except when comparing with null literals
     // https://eslint.org/docs/rules/eqeqeq
     'eqeqeq': ['error', 'always', {
@@ -43,7 +41,5 @@ module.exports = {
     // Prohibit invalid JSDoc annotations (when present)
     // https://eslint.org/docs/rules/valid-jsdoc
     'valid-jsdoc': 'error'
-
   }
-
 };


### PR DESCRIPTION
As discussed in https://github.com/wowserhq/eslint-config-wowser-base/pull/5#issuecomment-366582387, this PR removes padding from beginning/end of object literals in this repo.